### PR TITLE
docs(spec): v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ## Versions
 
-- [v0.1](versions/0.1.md) - *Under Development*
+- [v0.1](versions/0.1.md) - *Current*

--- a/versions/0.1.md
+++ b/versions/0.1.md
@@ -4,18 +4,18 @@
 
 - [types](#types)
   - [type](#type)
-- [commitUrlFormat](#commitUrlFormat)
-- [compareUrlFormat](#compareUrlFormat)
-- [issueUrlFormat](#issueUrlFormat)
+- [commitUrlFormat](#commiturlformat-string)
+- [compareUrlFormat](#compareurlformat-string)
+- [issueUrlFormat](#issueurlformat-string)
 
 
 ## Substitutions
-- [host]()
-- [owner]()
-- [repository]()
-- [hash]()
-- [previousTag]()
-- [nextTag]()
+- [host](#host)
+- [owner](#owner)
+- [repository](#repository)
+- [hash](#hash)
+- [previousTag](#previoustype)
+- [nextTag](#nexttag)
 
 ---
 

--- a/versions/0.1.md
+++ b/versions/0.1.md
@@ -1,0 +1,107 @@
+# Conventional Changelog Configuration Spec (v0.1)
+
+## Structure
+
+- [types](#types)
+  - [type](#type)
+- [commitUrlFormat](#commitUrlFormat)
+- [compareUrlFormat](#compareUrlFormat)
+- [issueUrlFormat](#issueUrlFormat)
+
+
+## Substitutions
+- [host]()
+- [owner]()
+- [repository]()
+- [hash]()
+- [previousTag]()
+- [nextTag]()
+
+---
+
+### types
+
+An array of [`type`](#type) objects representing the explicitly supported commit message types, and whether they should show up in generated CHANGELOGs.
+
+```json
+"types": [
+    { "type": "feat", "section": "Features"},
+    { "type": "fix", "section": "Bug Fixes"},
+    { "type": "test", "section": "Tests"},
+    { "type": "build", "section": "Build System"},
+    { "type": "ci", "hidden": true}
+]
+```
+
+#### type
+
+| name                      | type      | required  | default | description  |
+| ------------------------- | --------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| **type**                  | `string`  | ✔️        | `N/A`   | A string used to match `<type>`s used in the [Conventional Commits](https://www.conventionalcommits.org) convention. |
+| **section**               | `string`  | ✖️        | `N/A`   | The section where the matched commit `type` will display in the CHANGELOG. |
+| **hidden**                | `boolean` | ✖️        | `N/A`   | Set to `true` to hide matched commit `type`s in the CHANGELOG.                     |
+
+### commitUrlFormat (`string`)
+
+A URL representing a specific commit at a hash.
+
+```
+{{host}}/{{owner}}/{{repository}}/commit/{{hash}}
+```
+
+See [Substitutions]() for more details on substitutions.
+
+### compareUrlFormat (`string`)
+
+A URL representing the comparison between two git shas.
+
+```
+{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}
+```
+
+See [Substitutions]() for more details on substitutions.
+
+### issueUrlFormat (`string`)
+
+A URL representing the issueformat (allowing a different URL format to be swapped in for Gitlab, Bitbucket, etc):
+
+```
+{{host}}/{{owner}}/{{repository}}/issues/{{id}}
+```
+
+See [Substitutions]() for more details on substitutions.
+
+
+## Substitutions
+
+All substitutions use [Handlebar](https://handlebarsjs.com/) syntax and templating and will be interpolated as a `string`.
+
+### {{host}}
+Default: Normalized host found in `package.json`.
+
+Available to: `commitUrlFormat`, `compareUrlFormat`, `issueUrlFormat`
+
+### {{owner}}
+Default: Extracted from normalized `package.json` `repository.url` field.
+
+Available to: `commitUrlFormat`, `compareUrlFormat`, `issueUrlFormat`
+
+### {{repository}}
+Default: Extracted from normalized `package.json` `repository.url` field.
+
+Available to: `commitUrlFormat`, `compareUrlFormat`, `issueUrlFormat`
+
+### {{hash}}
+Default: The commit hash of the tagged release.
+
+Available to: `commitUrlFormat`
+
+### {{previousTag}}
+Default: Previous [semver](https://semver.org/) tag or the first commit hash if no previous tag is available.
+
+Available to: `compareUrlFormat`
+
+### {{currentTag}}
+Default: Current [semver](https://semver.org/) tag or  or `'v' + version` if no current tag is available.
+
+Available to: `compareUrlFormat`

--- a/versions/0.1.md
+++ b/versions/0.1.md
@@ -15,7 +15,7 @@
 - [repository](#repository)
 - [hash](#hash)
 - [previousTag](#previoustype)
-- [nextTag](#nexttag)
+- [currentTag](#currenttag)
 
 ---
 


### PR DESCRIPTION
- Adds `v0.1` spec structure based off of `ahmadnassri/har-spec`

see conventional-changelog/conventional-changelog-config-spec#1