### PR TITLE
docs: v1.0.0 of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ## Versions
 
-- [v0.1](versions/0.1.md) - *Current*
+- [v1.0.0](versions/1.0.0.md) - *Current*

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -1,12 +1,14 @@
-# Conventional Changelog Configuration Spec (v0.1)
+# Conventional Changelog Configuration Spec (v1.0.0)
 
 ## Structure
 
 - [types](#types)
   - [type](#type)
+- [preMajor](#premajor-boolean)
 - [commitUrlFormat](#commiturlformat-string)
 - [compareUrlFormat](#compareurlformat-string)
 - [issueUrlFormat](#issueurlformat-string)
+- [userUrlFormat](#userurlformat-string)
 
 
 ## Substitutions
@@ -41,6 +43,13 @@ An array of [`type`](#type) objects representing the explicitly supported commit
 | **section**               | `string`  | ✖️        | `N/A`   | The section where the matched commit `type` will display in the CHANGELOG. |
 | **hidden**                | `boolean` | ✖️        | `N/A`   | Set to `true` to hide matched commit `type`s in the CHANGELOG.                     |
 
+### preMajor(`boolean`)
+
+Boolean indicating whether or not the action being run (generating CHANGELOG,
+recommendedBump, etc.) is being performed for a pre-major release (`<1.0.0`).
+
+This config setting will generally be set by tooling and not a user.
+
 ### commitUrlFormat (`string`)
 
 A URL representing a specific commit at a hash.
@@ -70,6 +79,16 @@ A URL representing the issueformat (allowing a different URL format to be swappe
 ```
 
 See [Substitutions](#substitutions-1) for more details on substitutions.
+
+### userUrlFormat (`string`)
+
+A URL representing the a user's profile URL on GitHub, Gitlab, etc.
+
+```
+'{{host}}/{{user}}'
+```
+
+See [Substitutions]() for more details on substitutions.
 
 
 ## Substitutions
@@ -105,3 +124,9 @@ Available to: `compareUrlFormat`
 Default: Current [semver](https://semver.org/) tag or  or `'v' + version` if no current tag is available.
 
 Available to: `compareUrlFormat`
+
+### {{user}}
+Default: username to the right-hand-side of the `@` symbol in `@user` markup.
+
+Available to: `userUrlFormat`
+

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -81,7 +81,9 @@ See [Substitutions](#substitutions-1) for more details on substitutions.
 
 ### userUrlFormat (`string`)
 
-A URL representing the a user's profile URL on GitHub, Gitlab, etc.
+A URL representing the a user's profile URL on GitHub, Gitlab, etc. This URL
+is used for substituting `@bcoe` with `https://github.com/bcoe` in commit
+messages.
 
 ```
 {{host}}/{{user}}

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -10,7 +10,6 @@
 - [issueUrlFormat](#issueurlformat-string)
 - [userUrlFormat](#userurlformat-string)
 
-
 ## Substitutions
 - [host](#host)
 - [owner](#owner)
@@ -43,7 +42,7 @@ An array of [`type`](#type) objects representing the explicitly supported commit
 | **section**               | `string`  | ✖️        | `N/A`   | The section where the matched commit `type` will display in the CHANGELOG. |
 | **hidden**                | `boolean` | ✖️        | `N/A`   | Set to `true` to hide matched commit `type`s in the CHANGELOG.                     |
 
-### preMajor(`boolean`)
+### preMajor (`boolean`)
 
 Boolean indicating whether or not the action being run (generating CHANGELOG,
 recommendedBump, etc.) is being performed for a pre-major release (`<1.0.0`).
@@ -85,7 +84,7 @@ See [Substitutions](#substitutions-1) for more details on substitutions.
 A URL representing the a user's profile URL on GitHub, Gitlab, etc.
 
 ```
-'{{host}}/{{user}}'
+{{host}}/{{user}}
 ```
 
 See [Substitutions]() for more details on substitutions.
@@ -126,7 +125,7 @@ Default: Current [semver](https://semver.org/) tag or  or `'v' + version` if no 
 Available to: `compareUrlFormat`
 
 ### {{user}}
-Default: username to the right-hand-side of the `@` symbol in `@user` markup.
+Default: username to the right-hand-side of the `@` symbol in `@user` shorthand.
 
 Available to: `userUrlFormat`
 


### PR DESCRIPTION
YOLO let's make this v1.0.0 of the configuration language.

I've also added the missing `userUrlFormat` configuration, and the `preMajor` which can be used to vary behavior if a library version is prior to `<1.0.0`.