### PR TITLE
docs: adds releaseCommitMessageFormat

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -91,6 +91,16 @@ messages.
 
 See [Substitutions]() for more details on substitutions.
 
+### userUrlFormat (`string`)
+
+A URL representing the a user's profile URL on GitHub, Gitlab, etc.
+
+```
+'{{host}}/{{user}}'
+```
+
+See [Substitutions]() for more details on substitutions.
+
 
 ## Substitutions
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -96,7 +96,7 @@ See [Substitutions]() for more details on substitutions.
 A URL representing the a user's profile URL on GitHub, Gitlab, etc.
 
 ```
-'{{host}}/{{user}}'
+{{host}}/{{user}}
 ```
 
 See [Substitutions]() for more details on substitutions.

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -9,6 +9,7 @@
 - [compareUrlFormat](#compareurlformat-string)
 - [issueUrlFormat](#issueurlformat-string)
 - [userUrlFormat](#userurlformat-string)
+- [releaseCommitMessageFormat](#releasecommitmessageformat-string)
 
 ## Substitutions
 - [host](#host)
@@ -89,18 +90,17 @@ messages.
 {{host}}/{{user}}
 ```
 
-See [Substitutions]() for more details on substitutions.
+See [Substitutions](#substitutions-1) for more details on substitutions.
 
-### userUrlFormat (`string`)
+### releaseCommitMessageFormat (`string`)
 
-A URL representing the a user's profile URL on GitHub, Gitlab, etc.
+A string to be used to format the auto-generated release commit message.
 
 ```
-{{host}}/{{user}}
+chore(release): {{currentTag}}
 ```
 
-See [Substitutions]() for more details on substitutions.
-
+See [Substitutions](#substitutions-1) for more details on substitutions.
 
 ## Substitutions
 


### PR DESCRIPTION
- Adds `releaseCommitMessageFormat` based on the suggestion of `releaseMsgFormat` from @cristovaov

#3 