### PR TITLE
fix(typo): configuration property is `header`, not `title`.

### DIFF
--- a/versions/2.0.0/README.md
+++ b/versions/2.0.0/README.md
@@ -2,7 +2,7 @@
 
 ## Structure
 
-- [title](#title-string)
+- [header](#header-string)
 - [types](#types)
   - [type](#type)
 - [preMajor](#premajor-boolean)
@@ -22,9 +22,9 @@
 
 ---
 
-### title (`string`)
+### header (`string`)
 
-A string to be used as the main title of the CHANGELOG.
+A string to be used as the main header of the CHANGELOG.
 
 ```
 Changelog


### PR DESCRIPTION
This shouldn't require a version bump, the `schema.json` file [already uses `header` as the property](https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.0.0/schema.json#L7).