### PR TITLE
Update config spec to match implementation in `conventional-changelog`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@
 
 - [v1.0.0](versions/1.0.0/README.md)
 - [v2.0.0](versions/2.0.0/README.md)
-- [v2.1.0](versions/2.1.0/README.md)  - *Current*
+- [v2.1.0](versions/2.1.0/README.md)
+- [v2.2.0](versions/2.2.0/README.md)  - *Current*

--- a/versions/2.2.0/README.md
+++ b/versions/2.2.0/README.md
@@ -1,0 +1,172 @@
+# Conventional Changelog Configuration Spec (v2.1.0)
+
+## Structure
+
+- [header](#header-string)
+- [types](#types)
+  - [type](#type)
+- [preMajor](#premajor-boolean)
+- [commitUrlFormat](#commiturlformat-string)
+- [compareUrlFormat](#compareurlformat-string)
+- [issueUrlFormat](#issueurlformat-string)
+- [userUrlFormat](#userurlformat-string)
+- [releaseCommitMessageFormat](#releasecommitmessageformat-string)
+- [issuePrefixes](#issueprefixes-array-of-string)
+
+## Substitutions
+
+- [host](#host)
+- [owner](#owner)
+- [repository](#repository)
+- [hash](#hash)
+- [previousTag](#previoustype)
+- [currentTag](#currenttag)
+
+---
+
+### header (`string`)
+
+A string to be used as the main header of the CHANGELOG.
+
+```
+Changelog
+```
+
+### types
+
+An array of [`type`](#type) objects representing the explicitly supported commit message types, and whether they should show up in generated CHANGELOGs.
+
+```json
+"types": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "chore", "hidden": true},
+    {"type": "docs", "hidden": true},
+    {"type": "style", "hidden": true},
+    {"type": "refactor", "hidden": true},
+    {"type": "perf", "hidden": true},
+    {"type": "test", "hidden": true}
+]
+```
+
+#### type
+
+| name        | type      | required | default | description                                                                                                                   |
+| ----------- | --------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **type**    | `string`  | ✔️       | `N/A`   | A string used to match `<type>`s used in the [Conventional Commits](https://www.conventionalcommits.org) convention.          |
+| **scope**   | `string`  | ✖️       | `N/A`   | A string used to match `[optional scope]` used in the [Conventional Commits](https://www.conventionalcommits.org) convention. |
+| **section** | `string`  | ✖️       | `N/A`   | The section where the matched commit `type` will display in the CHANGELOG.                                                    |
+| **hidden**  | `boolean` | ✖️       | `N/A`   | Set to `true` to hide matched commit `type`s in the CHANGELOG.                                                                |
+
+### preMajor (`boolean`)
+
+Boolean indicating whether or not the action being run (generating CHANGELOG,
+recommendedBump, etc.) is being performed for a pre-major release (`<1.0.0`).
+
+This config setting will generally be set by tooling and not a user.
+
+### commitUrlFormat (`string`)
+
+A URL representing a specific commit at a hash.
+
+```
+{{host}}/{{owner}}/{{repository}}/commit/{{hash}}
+```
+
+See [Substitutions](#substitutions-1) for more details on substitutions.
+
+### compareUrlFormat (`string`)
+
+A URL representing the comparison between two git shas.
+
+```
+{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}
+```
+
+See [Substitutions](#substitutions-1) for more details on substitutions.
+
+### issueUrlFormat (`string`)
+
+A URL representing the issueformat (allowing a different URL format to be swapped in for Gitlab, Bitbucket, etc):
+
+```
+{{host}}/{{owner}}/{{repository}}/issues/{{id}}
+```
+
+See [Substitutions](#substitutions-1) for more details on substitutions.
+
+### userUrlFormat (`string`)
+
+A URL representing the a user's profile URL on GitHub, Gitlab, etc. This URL
+is used for substituting `@bcoe` with `https://github.com/bcoe` in commit
+messages.
+
+```
+{{host}}/{{user}}
+```
+
+See [Substitutions](#substitutions-1) for more details on substitutions.
+
+### releaseCommitMessageFormat (`string`)
+
+A string to be used to format the auto-generated release commit message.
+
+```
+chore(release): {{currentTag}}
+```
+
+See [Substitutions](#substitutions-1) for more details on substitutions.
+
+### issuePrefixes (array of `string`)
+
+An array of prefixes used to detect references to issues
+
+```
+['#']
+```
+
+## Substitutions
+
+All substitutions use [Handlebar](https://handlebarsjs.com/) syntax and templating and will be interpolated as a `string`.
+
+### {{host}}
+
+Default: Normalized host found in `package.json`.
+
+Available to: `commitUrlFormat`, `compareUrlFormat`, `issueUrlFormat`
+
+### {{owner}}
+
+Default: Extracted from normalized `package.json` `repository.url` field.
+
+Available to: `commitUrlFormat`, `compareUrlFormat`, `issueUrlFormat`
+
+### {{repository}}
+
+Default: Extracted from normalized `package.json` `repository.url` field.
+
+Available to: `commitUrlFormat`, `compareUrlFormat`, `issueUrlFormat`
+
+### {{hash}}
+
+Default: The commit hash of the tagged release.
+
+Available to: `commitUrlFormat`
+
+### {{previousTag}}
+
+Default: Previous [semver](https://semver.org/) tag or the first commit hash if no previous tag is available.
+
+Available to: `compareUrlFormat`
+
+### {{currentTag}}
+
+Default: Current [semver](https://semver.org/) tag or or `'v' + version` if no current tag is available.
+
+Available to: `compareUrlFormat`
+
+### {{user}}
+
+Default: username to the right-hand-side of the `@` symbol in `@user` shorthand.
+
+Available to: `userUrlFormat`

--- a/versions/2.2.0/schema.json
+++ b/versions/2.2.0/schema.json
@@ -1,0 +1,101 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Conventional Changelog Configuration",
+    "description": "Describes the configuration options supported by conventional-config for upstream tooling.",
+    "type": "object",
+    "properties": {
+        "header": {
+            "type": "string",
+            "description": "A string to be used as the main header section of the CHANGELOG.",
+            "default": "# Changelog\n\n"
+        },
+        "types": {
+            "description": "An array of `type` objects representing the explicitly supported commit message types, and whether they should show up in generated `CHANGELOG`s.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/type"
+            },
+            "default": [
+                {"type": "feat", "section": "Features"},
+                {"type": "fix", "section": "Bug Fixes"},
+                {"type": "chore", "hidden": true},
+                {"type": "docs", "hidden": true},
+                {"type": "style", "hidden": true},
+                {"type": "refactor", "hidden": true},
+                {"type": "perf", "hidden": true},
+                {"type": "test", "hidden": true}
+            ]
+        },
+        "preMajor": {
+            "type": "boolean",
+            "description": "Boolean indicating whether or not the action being run (generating CHANGELOG, recommendedBump, etc.) is being performed for a pre-major release (<1.0.0).\n This config setting will generally be set by tooling and not a user.",
+            "default": false
+        },
+        "commitUrlFormat": {
+            "type": "string",
+            "description": "A URL representing a specific commit at a hash.",
+            "default": "{{host}}/{{owner}}/{{repository}}/commit/{{hash}}"
+        },
+        "compareUrlFormat": {
+            "type": "string",
+            "description": "A URL representing the comparison between two git SHAs.",
+            "default": "{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}"
+        },
+        "issueUrlFormat": {
+            "type": "string",
+            "description": "A URL representing the issue format (allowing a different URL format to be swapped in for Gitlab, Bitbucket, etc).",
+            "default": "{{host}}/{{owner}}/{{repository}}/issues/{{id}}"
+        },
+        "userUrlFormat": {
+            "type": "string",
+            "description": "A URL representing the a user's profile URL on GitHub, Gitlab, etc. This URL is used for substituting @bcoe with https://github.com/bcoe in commit messages.",
+            "default": "{{host}}/{{user}}"
+        },
+        "releaseCommitMessageFormat": {
+            "type": "string",
+            "description": "A string to be used to format the auto-generated release commit message.",
+            "default": "chore(release): {{currentTag}}"
+        },
+        "issuePrefixes": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "An array of prefixes used to detect references to issues",
+            "default": ["#"]
+        }
+    },
+    "definitions": {
+        "type": {
+            "description": "An object that describes a commit type's settings in the CHANGELOG",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "description": "A string used to match <type>s used in the Conventional Commits convention.",
+                    "type": "string"
+                },
+                "scope": {
+                    "description": "A string used to match `[optional scope]` used in the Conventional Commits convention.",
+                    "type": "string"
+                },
+                "section": {
+                    "description": "The section where the matched commit type will display in the CHANGELOG.",
+                    "type": "string"
+                },
+                "hidden": {
+                    "description": "Set to `true` to hide matched commit types in the CHANGELOG.",
+                    "type": "boolean"
+                }
+            },
+            "required": ["type"],
+            "oneOf": [
+                {
+                    "required": ["section"]
+                },
+                {
+                    "required": ["hidden"]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
In the [code for `conventional-changelog`](https://github.com/conventional-changelog/conventional-changelog/blob/bfe3bf1c49d4a125474b398b2d304749fd3b56c7/packages/conventional-changelog-conventionalcommits/writer-opts.js#L60) it shows that the `types` object in `writerOpts` can take in a scope parameter in addition to the existing ones. 

This PR updates the spec & documentation to match its implementation in `conventional-changelog`